### PR TITLE
Drastically speed up asset cache checks

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ dependencyResolutionManagement {
         library 'utils-download', 'net.minecraftforge', 'download-utils'  version '0.3.0'
         library 'utils-hash',     'net.minecraftforge', 'hash-utils'      version '0.1.9'
         library 'utils-data',     'net.minecraftforge', 'json-data-utils' version '0.2.1'
-        library 'utils-logging',  'net.minecraftforge', 'log-utils'       version '0.3.1'
+        library 'utils-logging',  'net.minecraftforge', 'log-utils'       version '0.3.2'
         bundle 'utils', [ 'utils-download', 'utils-hash', 'utils-data', 'utils-logging' ]
 
         library 'nulls', 'org.jetbrains', 'annotations' version '26.0.2'

--- a/src/main/java/net/minecraftforge/launcher/DownloadAssets.java
+++ b/src/main/java/net/minecraftforge/launcher/DownloadAssets.java
@@ -49,8 +49,10 @@ final class DownloadAssets {
                 Log.info("Downloading missing asset: " + name);
                 DownloadUtils.downloadFile(file, repo + assetDest);
                 String newSha1 = HashFunction.SHA1.sneakyHash(file);
-                if (!newSha1.equals(asset.hash))
+                if (!newSha1.equals(asset.hash)) {
+                    file.delete();
                     throw new IllegalStateException(String.format("Failed to verify asset %s. Expected %s got %s", name, asset.hash, newSha1));
+                }
             } catch (Exception e) {
                 throw new IllegalStateException("Failed to download " + name, e);
             }


### PR DESCRIPTION
Previously, every asset in the game was read from disk and hashed on cache hit. There's thousands of these files and it's a sizable amount of data to read from disk (audio files, textures, lang files, etc).

This PR changes the logic to instead do hash checks after downloading, trusting that the files on disk haven't been corrupted since last successful download. This also fixes a bug where an asset that was just downloaded might be corrupted and not detected until next launch.

Went from around 1.5s -> 200ms. Both cases were with a RAM cache mind you (PrimoCache), so actual gains are even higher for most users that will be reading from SSD or (gasp!) HDD.