### PR TITLE
Simplify file cache checks

### DIFF
--- a/src/main/java/net/minecraftforge/launcher/DownloadAssets.java
+++ b/src/main/java/net/minecraftforge/launcher/DownloadAssets.java
@@ -34,9 +34,10 @@ final class DownloadAssets {
             AssetsIndex.Asset asset = entry.getValue();
             String assetDest = getAssetDest(asset.hash);
             File file = new File(objectsDir, assetDest);
-            if (file.exists()) {
-                Main.LOGGER.debug("Considering existing file with size " + file.length() + " for " + name);
-                if (file.length() == asset.size) {
+            long fileLength = file.length();
+            if (fileLength > 0) {
+                Main.LOGGER.debug("Considering existing file with size " + fileLength + " for " + name);
+                if (fileLength == asset.size) {
                     Main.LOGGER.debug("Size check succeeded. Skipping.");
                     continue;
                 }
@@ -64,9 +65,8 @@ final class DownloadAssets {
 
     private static File downloadIndex(MinecraftVersion versionJson, File assetsDir) {
         File index = new File(assetsDir, "indexes/" + versionJson.assetIndex.id + ".json");
-        if (index.exists() && index.length() == versionJson.assetIndex.size) {
+        if (index.length() == versionJson.assetIndex.size)
             return index;
-        }
 
         if (!index.getParentFile().getAbsoluteFile().exists() && !index.getParentFile().getAbsoluteFile().mkdirs())
             throw new IllegalArgumentException("Failed to create index directory: " + index.getParentFile());

--- a/src/main/java/net/minecraftforge/launcher/DownloadAssets.java
+++ b/src/main/java/net/minecraftforge/launcher/DownloadAssets.java
@@ -35,7 +35,7 @@ final class DownloadAssets {
             String assetDest = getAssetDest(asset.hash);
             File file = new File(objectsDir, assetDest);
             long fileLength = file.length();
-            if (fileLength > 0) {
+            if (fileLength != 0) {
                 Main.LOGGER.debug("Considering existing file with size " + fileLength + " for " + name);
                 if (fileLength == asset.size) {
                     Main.LOGGER.debug("Size check succeeded. Skipping.");

--- a/src/main/java/net/minecraftforge/launcher/Main.java
+++ b/src/main/java/net/minecraftforge/launcher/Main.java
@@ -161,7 +161,7 @@ public final class Main {
             // we're looking for the first "--"
             int splitIdx = -1;
             for (int i = 0; i < args.length; i++) {
-                if (args[i].equals("--")) {
+                if ("--".equals(args[i])) {
                     splitIdx = i;
                     break;
                 }


### PR DESCRIPTION
The javadocs for File#length() state that it returns 0 if the file does not exist, so the exists() check is redundant. The length was also being queried from the filesystem twice instead of stored in a local variable.

This PR fixes those things which theoretically improves performance. ~~I've not tested this yet as FG7's fgtools appears to be hardcoded to download from the Forge maven with no means of overriding it to use mavenLocal(), which makes it a bit tedious.~~

Update: tested and got a decent speedup considering how minimal the changes are. See this comment for numbers: https://github.com/MinecraftForge/SlimeLauncher/pull/8#issuecomment-4085953455